### PR TITLE
feature: allow bare imports in clients

### DIFF
--- a/client/src/utils/pg/client/client.ts
+++ b/client/src/utils/pg/client/client.ts
@@ -305,7 +305,7 @@ export class PgClient {
    */
   private static async _importPackages(code: string) {
     const importRegex = new RegExp(
-      /import\s+((\*\s+as\s+(\w+))|({[\s+\w+\s+,]*})|(\w+))\s+from\s+["|'](.+)["|']/gm
+      /import\s+(?:((\*\s+as\s+(\w+))|({[\s+\w+\s+,]*})|(\w+))\s+from\s+)?["|'](.+)["|']/gm
     );
     let importMatch: RegExpExecArray | null;
 


### PR DESCRIPTION
# Summary

This regex presupposes that imports will have specifiers, or whatever they're called. This PR aims to enable ‘bare’ imports like this:

```ts
import "foo";
```

The next PR in this stack makes use of this.
